### PR TITLE
Using streams instead of tmpDir & file to upload to Gyazo

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "html2sb": "^0.1.3",
     "html2sb-compiler": "^0.3.1",
     "htmlparser2": "^3.9.2",
+    "into-stream": "^3.1.0",
     "md5": "^2.2.1",
     "proxyquire": "^1.7.10"
   },

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,3 @@
-import fs from 'fs'
 import md5 from 'md5'
 import htmlparser from 'htmlparser2'
 import Html2SbCompiler from 'html2sb-compiler'

--- a/src/main.js
+++ b/src/main.js
@@ -2,6 +2,7 @@ import fs from 'fs'
 import md5 from 'md5'
 import htmlparser from 'htmlparser2'
 import Html2SbCompiler from 'html2sb-compiler'
+import intoStream from 'into-stream'
 import {find, findAll} from './libs/utils'
 import uploadImage from './libs/uploadImage'
 
@@ -28,20 +29,12 @@ export default async (input) => {
 
     let resources = {}
 
-    const tmpDir = '/tmp/enex2sb-image-tmp-' + Date.now()
-    try {
-      fs.mkdirSync(tmpDir)
-    } catch (e) {
-
-    }
     await Promise.all(findAll('resource', note).map(async (resource) => {
       const mimeType = find('mime', resource).children[0].data
       if (/^image\/.*/.test(mimeType)) {
         const file = new Buffer(find('data', resource).children[0].data, 'base64')
         const calculatedMd5 = md5(file)
-        const filepath = `${tmpDir}/${calculatedMd5}.${mimeType.split('/')[1]}`
-        fs.appendFileSync(filepath, file)
-        const res = await uploadImage(filepath)
+        const res = await uploadImage(intoStream(file))
         resources[calculatedMd5] = res.data.permalink_url
       }
     }))

--- a/yarn.lock
+++ b/yarn.lock
@@ -1374,6 +1374,13 @@ form-data@~2.1.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
+from2@^2.1.1:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/from2/-/from2-2.3.0.tgz#8bfb5502bde4a4d36cfdeea007fcca21d7e382af"
+  dependencies:
+    inherits "^2.0.1"
+    readable-stream "^2.0.0"
+
 fs-readdir-recursive@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz#8cd1745c8b4f8a29c8caec392476921ba195f560"
@@ -1650,6 +1657,13 @@ inherits@2, inherits@^2.0.1, inherits@~2.0.0, inherits@~2.0.1:
 ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
+
+into-stream@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/into-stream/-/into-stream-3.1.0.tgz#96fb0a936c12babd6ff1752a17d05616abd094c6"
+  dependencies:
+    from2 "^2.1.1"
+    p-is-promise "^1.1.0"
 
 invariant@^2.2.0:
   version "2.2.2"
@@ -2188,6 +2202,10 @@ output-file-sync@^1.1.0:
     graceful-fs "^4.1.4"
     mkdirp "^0.5.1"
     object-assign "^4.1.0"
+
+p-is-promise@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-1.1.0.tgz#9c9456989e9f6588017b0434d56097675c3da05e"
 
 package-hash@^1.1.0:
   version "1.2.0"


### PR DESCRIPTION
`gyazo-api` supports streams. With `into-streams` we can avoid having to write the file to the disk before uploading it to gyazo