### PR TITLE
Lightweight md5

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "html2sb": "^0.1.3",
     "html2sb-compiler": "^0.3.1",
     "htmlparser2": "^3.9.2",
+    "into-stream": "^3.1.0",
     "md5": "^2.2.1",
     "proxyquire": "^1.7.10"
   },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "html2sb-compiler": "^0.3.1",
     "htmlparser2": "^3.9.2",
     "into-stream": "^3.1.0",
-    "md5": "^2.2.1",
+    "nano-md5": "^1.0.3",
     "proxyquire": "^1.7.10"
   },
   "ava": {

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-import md5 from 'md5'
+import md5 from 'nano-md5'
 import htmlparser from 'htmlparser2'
 import Html2SbCompiler from 'html2sb-compiler'
 import intoStream from 'into-stream'
@@ -32,7 +32,7 @@ export default async (input) => {
       const mimeType = find('mime', resource).children[0].data
       if (/^image\/.*/.test(mimeType)) {
         const file = new Buffer(find('data', resource).children[0].data, 'base64')
-        const calculatedMd5 = md5(file)
+        const calculatedMd5 = md5.fromBytes(file.toString('latin1')).toHex()
         const res = await uploadImage(intoStream(file))
         resources[calculatedMd5] = res.data.permalink_url
       }

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,3 @@
-import fs from 'fs'
 import md5 from 'md5'
 import htmlparser from 'htmlparser2'
 import Html2SbCompiler from 'html2sb-compiler'

--- a/src/main.js
+++ b/src/main.js
@@ -2,6 +2,7 @@ import fs from 'fs'
 import md5 from 'md5'
 import htmlparser from 'htmlparser2'
 import Html2SbCompiler from 'html2sb-compiler'
+import intoStream from 'into-stream'
 import {find, findAll} from './libs/utils'
 import uploadImage from './libs/uploadImage'
 
@@ -28,20 +29,12 @@ export default async (input) => {
 
     let resources = {}
 
-    const tmpDir = '/tmp/enex2sb-image-tmp-' + Date.now()
-    try {
-      fs.mkdirSync(tmpDir)
-    } catch (e) {
-
-    }
     await Promise.all(findAll('resource', note).map(async (resource) => {
       const mimeType = find('mime', resource).children[0].data
       if (/^image\/.*/.test(mimeType)) {
         const file = new Buffer(find('data', resource).children[0].data, 'base64')
         const calculatedMd5 = md5(file)
-        const filepath = `${tmpDir}/${calculatedMd5}.${mimeType.split('/')[1]}`
-        fs.appendFileSync(filepath, file)
-        const res = await uploadImage(filepath)
+        const res = await uploadImage(intoStream(file))
         resources[calculatedMd5] = res.data.permalink_url
       }
     }))

--- a/yarn.lock
+++ b/yarn.lock
@@ -1374,6 +1374,13 @@ form-data@~2.1.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
+from2@^2.1.1:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/from2/-/from2-2.3.0.tgz#8bfb5502bde4a4d36cfdeea007fcca21d7e382af"
+  dependencies:
+    inherits "^2.0.1"
+    readable-stream "^2.0.0"
+
 fs-readdir-recursive@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz#8cd1745c8b4f8a29c8caec392476921ba195f560"
@@ -1650,6 +1657,13 @@ inherits@2, inherits@^2.0.1, inherits@~2.0.0, inherits@~2.0.1:
 ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
+
+into-stream@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/into-stream/-/into-stream-3.1.0.tgz#96fb0a936c12babd6ff1752a17d05616abd094c6"
+  dependencies:
+    from2 "^2.1.1"
+    p-is-promise "^1.1.0"
 
 invariant@^2.2.0:
   version "2.2.2"
@@ -2188,6 +2202,10 @@ output-file-sync@^1.1.0:
     graceful-fs "^4.1.4"
     mkdirp "^0.5.1"
     object-assign "^4.1.0"
+
+p-is-promise@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-1.1.0.tgz#9c9456989e9f6588017b0434d56097675c3da05e"
 
 package-hash@^1.1.0:
   version "1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -981,10 +981,6 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-charenc@~0.0.1:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
-
 chokidar@^1.0.0, chokidar@^1.4.2:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.6.1.tgz#2f4447ab5e96e50fb3d789fd90d4c72e0e4c70c2"
@@ -1112,10 +1108,6 @@ cross-spawn@^4.0.0:
   dependencies:
     lru-cache "^4.0.1"
     which "^1.2.9"
-
-crypt@~0.0.1:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
 
 cryptiles@2.x.x:
   version "2.0.5"
@@ -1685,7 +1677,7 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
-is-buffer@^1.0.2, is-buffer@~1.1.1:
+is-buffer@^1.0.2:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.4.tgz#cfc86ccd5dc5a52fa80489111c6920c457e2d98b"
 
@@ -1986,14 +1978,6 @@ md5-o-matic@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/md5-o-matic/-/md5-o-matic-0.1.1.tgz#822bccd65e117c514fab176b25945d54100a03c3"
 
-md5@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/md5/-/md5-2.2.1.tgz#53ab38d5fe3c8891ba465329ea23fac0540126f9"
-  dependencies:
-    charenc "~0.0.1"
-    crypt "~0.0.1"
-    is-buffer "~1.1.1"
-
 meow@^3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
@@ -2085,6 +2069,10 @@ multimatch@^2.1.0:
 nan@^2.3.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.5.0.tgz#aa8f1e34531d807e9e27755b234b4a6ec0c152a8"
+
+nano-md5@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/nano-md5/-/nano-md5-1.0.3.tgz#ff517583e20d83636593ac0eb81bdaa540f9dae1"
 
 node-pre-gyp@^0.6.29:
   version "0.6.32"


### PR DESCRIPTION
The md5 implementation used currently relies on `crypto` and is generally quite heavy.  `nano-md5` is significantly smaller.

Note: This PR is based on #6  and should be merged after #6!