### PR TITLE
Moving stream to uploadImage and fixing upload.

### DIFF
--- a/src/libs/uploadImage.js
+++ b/src/libs/uploadImage.js
@@ -1,6 +1,10 @@
 import Gyazo from 'gyazo-api'
+import intoStream from 'into-stream'
+
 const client = new Gyazo(process.env.GYAZO_ACCESS_TOKEN)
 
-export default async (filepath) => {
-  return await client.upload(filepath)
+export default async (file) => {
+  const stream = intoStream(file)
+  stream.path = 'evernote-imported-file'
+  return await client.upload(stream)
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,6 @@
 import md5 from 'nano-md5'
 import htmlparser from 'htmlparser2'
 import Html2SbCompiler from 'html2sb-compiler'
-import intoStream from 'into-stream'
 import {find, findAll} from './libs/utils'
 import uploadImage from './libs/uploadImage'
 
@@ -33,7 +32,7 @@ export default async (input) => {
       if (/^image\/.*/.test(mimeType)) {
         const file = new Buffer(find('data', resource).children[0].data, 'base64')
         const calculatedMd5 = md5.fromBytes(file.toString('latin1')).toHex()
-        const res = await uploadImage(intoStream(file))
+        const res = await uploadImage(file)
         resources[calculatedMd5] = res.data.permalink_url
       }
     }))


### PR DESCRIPTION
The tests ignore if the sending of the data actually works or not. That is why it is broken currently. 🙇 _(sorry)_ This PR fixes the upload by giving the stream a path. Subsequently request can use this filename [here](https://github.com/form-data/form-data/blob/67b8a8e4bcd24a6dc971fef6d5e855099710ed9f/lib/form_data.js#L217). And subsequently Gyazo accepts the stream 😅 