### PR TITLE
Moved ava to dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "author": "pastak <pasta0915@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "ava": "^0.17.0",
     "commander": "^2.9.0",
     "gyazo-api": "^0.3.1",
     "html2sb": "^0.1.3",
@@ -40,6 +39,7 @@
     "babel": "inherit"
   },
   "devDependencies": {
+    "ava": "^0.17.0",
     "babel-cli": "^6.18.0",
     "babel-polyfill": "^6.20.0",
     "babel-preset-stage-0": "^6.24.1",


### PR DESCRIPTION
`ava` is a test framework and should be a dev dependency, right?