### PR TITLE
Use the browser implementation

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -1,6 +1,6 @@
 require('babel-register')
 
 import main from './main'
-import uploadImage from './libs/uploadImage'
+import uploadImage from './browser/uploadImage'
 
 export default main.bind(null, uploadImage)


### PR DESCRIPTION
It seems like in https://github.com/pastak/enex2sb/commit/31bccb6646db5e4aa8c3dc5c47323132d9e2d7a1#diff-b056c1ad802eb5041886154caaf3a3d4L4 the reference was changed from `./browser/uploadImage` to `./libs/uploadImage`. Mistake?!